### PR TITLE
Privacy Policy translation (fixes Issue #2951)

### DIFF
--- a/app/code/Magento/Cms/view/frontend/layout/default.xml
+++ b/app/code/Magento/Cms/view/frontend/layout/default.xml
@@ -13,7 +13,7 @@
         <referenceBlock name="footer_links">
             <block class="Magento\Framework\View\Element\Html\Link\Current" name="privacy-policy-link">
                 <arguments>
-                    <argument name="label" xsi:type="string">Privacy and Cookie Policy</argument>
+                    <argument name="label" xsi:type="string" translate="true">Privacy and Cookie Policy</argument>
                     <argument name="path" xsi:type="string">privacy-policy-cookie-restriction-mode</argument>
                 </arguments>
             </block>


### PR DESCRIPTION
Lacking translate="true" for Privacy and Cookie Policy footer link.